### PR TITLE
Fix issue with ogg/audio file in chrome.

### DIFF
--- a/src/components/AvWaveform.js
+++ b/src/components/AvWaveform.js
@@ -221,7 +221,7 @@ const AvWaveform = {
       const segSize = Math.ceil(buffer.length / this.canvWidth)
       const width = this.canvWidth
       const height = this.canvHeight
-      this.duration = this.audio.duration
+      this.duration = buffer.duration // while we have buffer why we don't use it ?
 
       for (let c = 0; c < buffer.numberOfChannels; c++) {
         const data = buffer.getChannelData(c)


### PR DESCRIPTION
I am using vue-audio-visual. And i am stuck with an issue that i cannot see wave-form in chrome for ogg filetype.
by changeing this line i can